### PR TITLE
Fix typo

### DIFF
--- a/start-fly-log-transporter.sh
+++ b/start-fly-log-transporter.sh
@@ -8,7 +8,7 @@ trap 'kill $(jobs -p)' EXIT
 [[ ! -z "$HUMIO_TOKEN" ]] && cat /etc/vector/honeycomb.toml >> /etc/vector/vector.toml 
 [[ ! -z "$LOGDNA_API_KEY" ]] && cat /etc/vector/logdna.toml >> /etc/vector/vector.toml 
 if [ ! -z "$NEW_RELIC_INSERT_KEY" ] || [ ! -z "$NEW_RELIC_LICENSE_KEY" ]; then
-  cat /etc/vector/honeycomb.toml >> /etc/vector/vector.toml 
+  cat /etc/vector/new-relic.toml >> /etc/vector/vector.toml 
   [[ ! -z "$NEW_RELIC_INSERT_KEY" ]] && echo "  insert_key = \"${NEW_RELIC_INSERT_KEY}\"" >> /etc/vector/vector.toml 
   [[ ! -z "$NEW_RELIC_LICENSE_KEY" ]] && echo "  license_key = \"${NEW_RELIC_LICENSE_KEY}\"" >> /etc/vector/vector.toml 
 fi


### PR DESCRIPTION
A little typo, beside that everything is working 100%, got the sync with NewRelic humming along nicely. Enjoying fly a lot!

Related to this. The readme: https://github.com/superfly/fly-log-shipper#new-relic was also not 100% clear, it says that both config variables are optional, this is not the case, one of both needs to be provided.

- `NEW_RELIC_INSERT_KEY`
- `NEW_RELIC_LICENSE_KEY`

New Relic recommends to use `NEW_RELIC_LICENSE_KEY` see: https://docs.newrelic.com/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/vector-output-sink-log-forwarding/