### PR TITLE
Adding action to publish Docker image to packages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
   push_to_registry:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       packages: write
     name: Push image
   
@@ -42,14 +42,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Release
-        id: release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false


### PR DESCRIPTION
This pull request adds a GitHub action to publish Docker image to GitHub package repository.

The purpose is to make it easy to consume the log shipper without needing to clone this repository. This allows for a simple `fly.toml` file and just an environment secret to get up and running.

For instance:

**fly.toml:**
```
app = "<app name>"

[build]
  image = "ghcr.io/superfly/fly-log-shipper:latest"

[metrics]
  path = "/metrics"
  port = 9598
```

It is currently configured to update on new tags, but maybe you prefer push to master for a new build of the image?