### PR TITLE
Add Logflare sink 👊 

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ Create a new Fly app based on this Dockerfile and configure using the following 
 | ---------------- | -------------- |
 | `LOGDNA_API_KEY` | LogDNA API key |
 
+### Logflare
+
+| Secret                  | Description                                             |
+| ----------------------- | ------------------------------------------------------- |
+| `LOGFLARE_API_KEY`      | Logflare ingest API key                                 |
+| `LOGFLARE_SOURCE_TOKEN` | Logflare source token (uuid on your Logflare dashboard) |
+
 ### Logtail
 
 | Secret          | Description        |

--- a/start-fly-log-transporter.sh
+++ b/start-fly-log-transporter.sh
@@ -16,6 +16,7 @@ fi
 [[ ! -z "$SEMATEXT_TOKEN" ]] && cat /etc/vector/sematext.toml >> /etc/vector/vector.toml
 [[ ! -z "$UPTRACE_API_KEY" ]] && [[ ! -z "$UPTRACE_PROJECT" ]] && cat /etc/vector/uptrace.toml >> /etc/vector/vector.toml
 [[ ! -z "$LOGTAIL_TOKEN" ]] && cat /etc/vector/logtail.toml >> /etc/vector/vector.toml
+[[ ! -z "$LOGFLARE_API_KEY" ]] && [[ ! -z "$LOGFLARE_SOURCE_TOKEN" ]] && cat /etc/vector/logflare.toml >> /etc/vector/vector.toml
 
 vector -c /etc/vector/vector.toml &
 while [ ! -e /var/run/vector.sock ]; do

--- a/vector-configs/sinks/logflare.toml
+++ b/vector-configs/sinks/logflare.toml
@@ -1,0 +1,6 @@
+[sinks.logflare]
+  type = "http"
+  inputs = ["log_json"]
+  uri = "https://api.logflare.app/logs/vector?api_key=${LOGFLARE_API_KEY}&source=${LOGFLARE_SOURCE_TOKEN}"
+  encoding.codec = "json"
+  compression = "none"


### PR DESCRIPTION
Seems there are some people using Fly and Logflare ❤️

This should make it easy for them to ship logs to Logflare!

Logs look like:

<img width="1384" alt="Screen Shot 2021-11-10 at 11 18 13 AM" src="https://user-images.githubusercontent.com/1019814/141170537-d202c830-57e8-4333-8936-751ce2b9dc05.png">

I would like to clean up the log message a bit.  And if we get the level at the top level of the metadata the chart will be grouped by level with `error` being red, etc.  But maybe I'll just edit the Vector remap in a different fork as an example.

Query by app name: `m.fly.app.name:"fly-swatter"`

Query by level: `m.host.log.level:"error"`



