### PR TITLE
fix: duplicate messages when using queue

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,10 +71,11 @@ func main() {
 		nc.QueueSubscribe(subject, queue, func(msg *nats.Msg) {
 			printMsg(msg)
 		})
+	} else {
+		nc.Subscribe(subject, func(msg *nats.Msg) {
+			printMsg(msg)
+		})
 	}
-	nc.Subscribe(subject, func(msg *nats.Msg) {
-		printMsg(msg)
-	})
 	nc.Flush()
 
 	if err := nc.LastError(); err != nil {


### PR DESCRIPTION
When using the queue option, two subscriptions are created, one queue based and one normal.
This results in duplicate messages being logged and the queue option not functioning as desired.

Side note: recommend using squash merge when merging PRs to maintain a clean history.