### PR TITLE
Exposes aws_s3 sink endpoint setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,20 @@ Create a new Fly app based on this Dockerfile and configure using the following 
 | -------------- | ---------------------------------------------------------------------------------------------------------------- |
 | `ORG`          | Organisation slug                                                                                                |
 | `ACCESS_TOKEN` | Fly personal access token                                                                                        |
-| `SUBJECT`        | Subject to subscribe to. See [[NATS]] below (defaults to `logs.>`)                                             |
+| `SUBJECT`      | Subject to subscribe to. See [[NATS]] below (defaults to `logs.>`)                                               |
 | `QUEUE`        | Arbitrary queue name if you want to run multiple log processes for HA and avoid duplicate messages being shipped |
 
 ## Provider configuration
 
 ### AWS S3
 
-| Secret                  | Description                                  |
-| ----------------------- | -------------------------------------------- |
-| `AWS_ACCESS_KEY_ID`     | AWS Access key with access to the log bucket |
-| `AWS_SECRET_ACCESS_KEY` | AWS secret access key                        |
-| `AWS_BUCKET`            | AWS S3 bucket to store logs in               |
-| `AWS_REGION`            | Region for the bucket                        |
+| Secret                  | Description                                                                             |
+| ----------------------- | --------------------------------------------------------------------------------------- |
+| `AWS_ACCESS_KEY_ID`     | AWS Access key with access to the log bucket                                            |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret access key                                                                   |
+| `AWS_BUCKET`            | AWS S3 bucket to store logs in                                                          |
+| `AWS_REGION`            | Region for the bucket                                                                   |
+| `S3_ENDPOINT`           | (optional) Endpoint URL for S3 compatible object stores such as Cloudflare R2 or Wasabi |
 
 ### Datadog
 
@@ -75,6 +76,7 @@ Create a new Fly app based on this Dockerfile and configure using the following 
 | `LOKI_PASSWORD` | Loki Password |
 
 ### New Relic
+
 One of these is required for New Relic logs. New Relic recommend the license key be used (ref: https://docs.newrelic.com/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/vector-output-sink-log-forwarding/)
 
 | Secret                  | Description                      |
@@ -95,7 +97,6 @@ One of these is required for New Relic logs. New Relic recommend the license key
 | `SEMATEXT_REGION` | Sematext region |
 | `SEMATEXT_TOKEN`  | Sematext token  |
 
-
 ### Uptrace
 
 | Secret            | Description        |
@@ -105,11 +106,11 @@ One of these is required for New Relic logs. New Relic recommend the license key
 
 ### EraSearch
 
-| Secret                  | Description                                  |
-| ----------------------- | -------------------------------------------- |
-| `ERASEARCH_URL`         | EraSearch Endpoint                           |   
-| `ERASEARCH_AUTH`        | EraSearch User                               |
-| `ERASEARCH_INDEX`       | EraSearch Index you want to use              |
+| Secret            | Description                     |
+| ----------------- | ------------------------------- |
+| `ERASEARCH_URL`   | EraSearch Endpoint              |
+| `ERASEARCH_AUTH`  | EraSearch User                  |
+| `ERASEARCH_INDEX` | EraSearch Index you want to use |
 
 ---
 

--- a/start-fly-log-transporter.sh
+++ b/start-fly-log-transporter.sh
@@ -3,7 +3,10 @@ set -e
 trap 'kill $(jobs -p)' EXIT
 
 [[ ! -z "$DATADOG_API_KEY" ]] && cat /etc/vector/datadog.toml >> /etc/vector/vector.toml
-[[ ! -z "$AWS_ACCESS_KEY_ID" ]] && [[ ! -z "$AWS_BUCKET" ]] && cat /etc/vector/aws_s3.toml >> /etc/vector/vector.toml
+if [ ! -z "$AWS_ACCESS_KEY_ID" ] && [ ! -z "$AWS_BUCKET" ]; then
+  cat /etc/vector/aws_s3.toml >> /etc/vector/vector.toml 
+  [[ ! -z "$S3_ENDPOINT" ]] && echo "  endpoint = \"${S3_ENDPOINT}\"" >> /etc/vector/vector.toml 
+fi
 [[ ! -z "$HONEYCOMB_API_KEY" ]] && cat /etc/vector/honeycomb.toml >> /etc/vector/vector.toml 
 [[ ! -z "$HUMIO_TOKEN" ]] && cat /etc/vector/humio.toml >> /etc/vector/vector.toml 
 [[ ! -z "$LOGDNA_API_KEY" ]] && cat /etc/vector/logdna.toml >> /etc/vector/vector.toml 


### PR DESCRIPTION
A small change that allows the optional setting of the [S3 endpoint URL](https://vector.dev/docs/reference/configuration/sinks/aws_s3/#endpoint) as `S3_ENDPOINT` environment variable to allow users to ship logs to a variety of S3 compatible object stores such as Cloudflare R2 and Wasabi.

Tested with R2 and AWS S3 (ie not setting `S3_ENDPOINT`).