### PR TITLE
Allowing Datadog site configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Create a new Fly app based on this [Dockerfile](./Dockerfile) and configure usin
 ### Datadog
 
 | Secret            | Description                                   |
-| ----------------- | --------------------------------------------- |
+| ----------------- | ----------------------------------------------|
 | `DATADOG_API_KEY` | API key for your Datadog account              |
 | `DATADOG_SITE`    | (optional) The Datadog site. ie: datadoghq.eu |
 

--- a/vector-configs/sinks/datadog.toml
+++ b/vector-configs/sinks/datadog.toml
@@ -3,6 +3,7 @@
   type = "datadog_logs" # required
   inputs = ["log_json"] # required
   api_key = "${DATADOG_API_KEY}" # required
+  site = "${DATADOG_SITE:-datadoghq.com}" # optional
   compression = "gzip" # optional, default
 
   # Healthcheck


### PR DESCRIPTION
This PR extends Datadog vector sink to include DD's site. Currently, it uses the default address, which is US but European users can use a different site