### PR TITLE
Automatically filter Vector configs with unresolved variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM timberio/vector:0.29.0
+FROM timberio/vector:0.28.1-debian
 COPY vector-configs /etc/vector/
 COPY ./start-fly-log-transporter.sh .
 CMD ["bash", "start-fly-log-transporter.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM timberio/vector:nightly-2022-07-26-debian
-COPY vector-configs/* /etc/vector/
+COPY vector-configs /etc/vector/
 COPY ./start-fly-log-transporter.sh .
 CMD ["bash", "start-fly-log-transporter.sh"]
 ENTRYPOINT []

--- a/start-fly-log-transporter.sh
+++ b/start-fly-log-transporter.sh
@@ -1,25 +1,11 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-[[ ! -z "$DATADOG_API_KEY" ]] && cat /etc/vector/datadog.toml >> /etc/vector/vector.toml
-if [ ! -z "$AWS_ACCESS_KEY_ID" ] && [ ! -z "$AWS_BUCKET" ]; then
-  cat /etc/vector/aws_s3.toml >> /etc/vector/vector.toml 
-  [[ ! -z "$S3_ENDPOINT" ]] && echo "  endpoint = \"${S3_ENDPOINT}\"" >> /etc/vector/vector.toml 
-fi
-[[ ! -z "$HONEYCOMB_API_KEY" ]] && cat /etc/vector/honeycomb.toml >> /etc/vector/vector.toml 
-[[ ! -z "$HUMIO_TOKEN" ]] && cat /etc/vector/humio.toml >> /etc/vector/vector.toml 
-[[ ! -z "$LOGDNA_API_KEY" ]] && cat /etc/vector/logdna.toml >> /etc/vector/vector.toml 
-if [ ! -z "$NEW_RELIC_INSERT_KEY" ] || [ ! -z "$NEW_RELIC_LICENSE_KEY" ]; then
-  cat /etc/vector/new_relic.toml >> /etc/vector/vector.toml 
-  [[ ! -z "$NEW_RELIC_INSERT_KEY" ]] && echo "  insert_key = \"${NEW_RELIC_INSERT_KEY}\"" >> /etc/vector/vector.toml 
-  [[ ! -z "$NEW_RELIC_LICENSE_KEY" ]] && echo "  license_key = \"${NEW_RELIC_LICENSE_KEY}\"" >> /etc/vector/vector.toml 
-fi
-[[ ! -z "$PAPERTRAIL_ENDPOINT" ]] && cat /etc/vector/papertrail.toml >> /etc/vector/vector.toml 
-[[ ! -z "$SEMATEXT_TOKEN" ]] && cat /etc/vector/sematext.toml >> /etc/vector/vector.toml
-[[ ! -z "$UPTRACE_API_KEY" ]] && [[ ! -z "$UPTRACE_PROJECT" ]] && cat /etc/vector/uptrace.toml >> /etc/vector/vector.toml
-[[ ! -z "$LOGTAIL_TOKEN" ]] && cat /etc/vector/logtail.toml >> /etc/vector/vector.toml
-[[ ! -z "$LOGFLARE_API_KEY" ]] && [[ ! -z "$LOGFLARE_SOURCE_TOKEN" ]] && cat /etc/vector/logflare.toml >> /etc/vector/vector.toml
-[[ ! -z "$ERASEARCH_URL" ]] && [[ ! -z "$ERASEARCH_INDEX" ]] && [[ ! -z "$ERASEARCH_AUTH" ]] && cat /etc/vector/erasearch.toml >> /etc/vector/vector.toml
-[[ ! -z "$LOKI_URL" ]] && [[ ! -z "$LOKI_USERNAME" ]] && [[ ! -z "$LOKI_PASSWORD" ]] && cat /etc/vector/loki.toml >> /etc/vector/vector.toml
+template() { eval $'cat <<_EOF\n'"$(awk '1;END{print"_EOF"}')"; }
+sponge() { cat <<<"$(cat)" >"$1"; }
+filter() { for i in "$@"; do template <"$i" | sponge "$i" || rm "$i"; done; }
+filter /etc/vector/sinks/*.toml 2>&-
+echo 'Configured sinks:'
+find /etc/vector/sinks -type f -exec basename -s '.toml' {} \;
 
-exec vector -c /etc/vector/vector.toml
+exec vector -c /etc/vector/vector.toml -C /etc/vector/sinks

--- a/vector-configs/sinks/aws_s3.toml
+++ b/vector-configs/sinks/aws_s3.toml
@@ -8,4 +8,4 @@
   encoding.codec = "ndjson"
   key_prefix = "{{fly.app.name}}/%F/" # optional, default
   healthcheck.enabled = true # optional, default
-
+  ${S3_ENDPOINT+endpoint = "$S3_ENDPOINT"}

--- a/vector-configs/sinks/humio.toml
+++ b/vector-configs/sinks/humio.toml
@@ -9,3 +9,4 @@
   # Encoding
   encoding.codec = "json"
 
+  ${HUMIO_ENDPOINT+endpoint = "$HUMIO_ENDPOINT"}

--- a/vector-configs/sinks/new_relic.toml
+++ b/vector-configs/sinks/new_relic.toml
@@ -2,5 +2,7 @@
   # General
   type = "new_relic_logs"
   inputs = ["log_json"]
-  compression = "gzip" 
-
+  compression = "gzip"
+  # Key: ${NEW_RELIC_LICENSE_KEY-$NEW_RELIC_INSERT_KEY}
+  ${NEW_RELIC_LICENSE_KEY+license_key = \"$NEW_RELIC_LICENSE_KEY\"}
+  ${NEW_RELIC_INSERT_KEY+insert_key = \"$NEW_RELIC_INSERT_KEY\"}

--- a/vector-configs/sinks/papertrail.toml
+++ b/vector-configs/sinks/papertrail.toml
@@ -1,5 +1,5 @@
 [sinks.papertrail]
   type = "papertrail"
   inputs = ["log_json"]
-  endpoint = "${PAPERTRAIL_ENDPOINT}" 
-
+  endpoint = "${PAPERTRAIL_ENDPOINT}"
+  encoding.codec = "${PAPERTRAIL_ENCODING_CODEC:-json}"


### PR DESCRIPTION
This PR replaces the string of conditionals in `start-fly-log-transporter.sh` with a Bash templating function that will render all configs as Bash heredocs, filtering out any components with unresolved variable references (which abort the template-rendering with `set -u`).

For the two sinks that had some special conditional logic (s3 and newrelic), I've moved the extra logic into the sink definition directly.