### PR TITLE
aws_s3: change codec

### DIFF
--- a/vector-configs/sinks/aws_s3.toml
+++ b/vector-configs/sinks/aws_s3.toml
@@ -5,7 +5,7 @@
   bucket = "${AWS_BUCKET}" 
   compression = "gzip" 
   region = "${AWS_REGION}"
-  encoding.codec = "ndjson"
+  encoding.codec = "json"
   key_prefix = "{{fly.app.name}}/%F/" # optional, default
   healthcheck.enabled = true # optional, default
 


### PR DESCRIPTION
No idea if this is correct, but this change suppresses the following error, and makes my logs ship:

```
ERROR vector::cli: Configuration error. error=unknown variant `ndjson`, expected one of `avro`, `gelf`, `json`, `logfmt`, `native`, `native_json`, `raw_message`, `text` for key `sinks.aws_s3`
```