### PR TITLE
chore(deps): update vector to 0.24.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM timberio/vector:nightly-2022-07-26-debian
+FROM timberio/vector:0.24.1-debian
 COPY vector-configs/* /etc/vector/
 COPY ./start-fly-log-transporter.sh .
 CMD ["bash", "start-fly-log-transporter.sh"]


### PR DESCRIPTION
1. Use latest stable release instead of a nightly
2. Avoid potential 404s due to cleaning up nightly releases upstream