### PR TITLE
Support axiom logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ Create a new Fly app based on this [Dockerfile](./Dockerfile) and configure usin
 | `AWS_REGION`            | Region for the bucket                                                                   |
 | `S3_ENDPOINT`           | (optional) Endpoint URL for S3 compatible object stores such as Cloudflare R2 or Wasabi |
 
+### Axiom
+
+| Secret          | Description   |
+| ----------------| --------------|
+| `AXIOM_TOKEN`   | Axiom token   |
+| `AXIOM_DATASET` | Axiom dataset |
+
 ### Datadog
 
 | Secret            | Description                      |

--- a/start-fly-log-transporter.sh
+++ b/start-fly-log-transporter.sh
@@ -21,5 +21,6 @@ fi
 [[ ! -z "$LOGFLARE_API_KEY" ]] && [[ ! -z "$LOGFLARE_SOURCE_TOKEN" ]] && cat /etc/vector/logflare.toml >> /etc/vector/vector.toml
 [[ ! -z "$ERASEARCH_URL" ]] && [[ ! -z "$ERASEARCH_INDEX" ]] && [[ ! -z "$ERASEARCH_AUTH" ]] && cat /etc/vector/erasearch.toml >> /etc/vector/vector.toml
 [[ ! -z "$LOKI_URL" ]] && [[ ! -z "$LOKI_USERNAME" ]] && [[ ! -z "$LOKI_PASSWORD" ]] && cat /etc/vector/loki.toml >> /etc/vector/vector.toml
+[[ ! -z "$AXIOM_TOKEN" ]] && [[ ! -z "$AXIOM_DATASET" ]] && cat /etc/vector/axiom.toml >> /etc/vector/vector.toml
 
 exec vector -c /etc/vector/vector.toml

--- a/vector-configs/sinks/axiom.toml
+++ b/vector-configs/sinks/axiom.toml
@@ -1,0 +1,6 @@
+[sinks.axiom]
+  type = "axiom"
+  inputs = ["log_json"]
+  token = "${AXIOM_TOKEN}"
+  dataset = "${AXIOM_DATASET}"
+


### PR DESCRIPTION
[Axiom](https://www.axiom.co/) provides a generous tiers and storage for logs, so that is why I want to try them out.

Turns out vector has axiom configuration available, hence this PR.

Nothing different than other log providers, simply set 2 variables `AXIOM_TOKEN` (obtained from their dashboard) and `AXIOM_DATASET`.

Sample below is the logs from the logs machine itself:
![image](https://user-images.githubusercontent.com/781254/190844946-aab11069-07b2-4cce-869f-df4df049f551.png)
