### PR TITLE
Datadog encoding fix plus site

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ Create a new Fly app based on this [Dockerfile](./Dockerfile) and configure usin
 
 ### Datadog
 
-| Secret            | Description                      |
-| ----------------- | -------------------------------- |
-| `DATADOG_API_KEY` | API key for your Datadog account |
+| Secret            | Description                                   |
+| ----------------- | --------------------------------------------- |
+| `DATADOG_API_KEY` | API key for your Datadog account              |
+| `DATADOG_SITE`    | (optional) The Datadog site. ie: datadoghq.eu |
 
 ### Honeycomb
 

--- a/start-fly-log-transporter.sh
+++ b/start-fly-log-transporter.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 set -e
 
-[[ ! -z "$DATADOG_API_KEY" ]] && cat /etc/vector/datadog.toml >> /etc/vector/vector.toml
+if [ ! -z "$DATADOG_API_KEY" ]; then 
+   cat /etc/vector/datadog.toml >> /etc/vector/vector.toml
+  [[ ! -z "$DATADOG_SITE" ]] && echo "  site = \"${DATADOG_SITE}\"" >> /etc/vector/vector.toml 
+fi
 if [ ! -z "$AWS_ACCESS_KEY_ID" ] && [ ! -z "$AWS_BUCKET" ]; then
   cat /etc/vector/aws_s3.toml >> /etc/vector/vector.toml 
   [[ ! -z "$S3_ENDPOINT" ]] && echo "  endpoint = \"${S3_ENDPOINT}\"" >> /etc/vector/vector.toml 

--- a/vector-configs/sinks/datadog.toml
+++ b/vector-configs/sinks/datadog.toml
@@ -5,9 +5,6 @@
   api_key = "${DATADOG_API_KEY}" # required
   compression = "gzip" # optional, default
 
-  # Encoding
-  encoding.codec = "json" # required
-
   # Healthcheck
   healthcheck.enabled = true # optional, default
 


### PR DESCRIPTION
Removed the encoding.codec since it is [not valid](https://vector.dev/docs/reference/configuration/sinks/datadog_logs/#encoding) and added the Datadog [site]( https://vector.dev/docs/reference/configuration/sinks/datadog_logs/#site)