### PR TITLE
ndjson is deprecated, use framing.method instead

### DIFF
--- a/vector-configs/sinks/aws_s3.toml
+++ b/vector-configs/sinks/aws_s3.toml
@@ -5,7 +5,8 @@
   bucket = "${AWS_BUCKET}" 
   compression = "gzip" 
   region = "${AWS_REGION}"
-  encoding.codec = "ndjson"
+  framing.method = "newline_delimited"
+  encoding.codec = "json"
   key_prefix = "{{fly.app.name}}/%F/" # optional, default
   healthcheck.enabled = true # optional, default
 


### PR DESCRIPTION
I was seeing this error in my logs:

> ERROR vector::cli: Configuration error. error=unknown variant `ndjson`, expected one of `avro`, `gelf`, `json`, `logfmt`, `native`, `native_json`, `raw_message`, `text` for key `sinks.aws_s3

It turns out `ndjson` has been deprecated: https://github.com/vectordotdev/vector/blob/master/website/content/en/highlights/2022-07-07-0-23-0-upgrade-guide.md#sink-encoding-value-ndjson-is-now-json-encoding--newline_delimited-framing-sink-encoding-ndjson-json