### PR TITLE
Fix breaking change in Vector uptrace config

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,15 @@ One of these is required for New Relic logs. New Relic recommend the license key
 
 ### Uptrace
 
-| Secret            | Description        |
-| ----------------- | ------------------ |
-| `UPTRACE_API_KEY` | Uptrace API key    |
-| `UPTRACE_PROJECT` | Uptrace project ID |
+| Secret                  | Description        |
+| -----------------       | ------------------ |
+| `UPTRACE_API_KEY`       | Uptrace API key    |
+| `UPTRACE_PROJECT`       | Uptrace project ID |
+| `UPTRACE_SINK_INPUT`    | `"log_json"`, etc. |
+| `UPTRACE_SINK_ENCODING` | `"json"`, etc.     |
+
+For UPTRACE_SINK_ENCODING Vector expects one of `avro`, `gelf`, `json`, `logfmt`, `native`,
+`native_json`, `raw_message`, `text` for key `sinks.uptrace`.
 
 ### EraSearch
 

--- a/vector-configs/sinks/uptrace.toml
+++ b/vector-configs/sinks/uptrace.toml
@@ -1,7 +1,7 @@
 [sinks.uptrace]
   type = "http"
-  inputs = ["log_json"]
-  encoding.codec = "ndjson"
+  inputs = ["${UPTRACE_SINK_INPUT}"]
+  encoding.codec = "${UPTRACE_SINK_ENCODING}"
   compression = "gzip"
   uri = "https://api.uptrace.dev/api/v1/vector-logs"
   headers.uptrace-dsn = "https://${UPTRACE_API_KEY}@api.uptrace.dev/${UPTRACE_PROJECT}"

--- a/vector-configs/sinks/uptrace.toml
+++ b/vector-configs/sinks/uptrace.toml
@@ -2,7 +2,7 @@
   type = "http"
   inputs = ["${UPTRACE_SINK_INPUT}"]
   encoding.codec = "${UPTRACE_SINK_ENCODING}"
+  framing.method = "newline_delimited"
   compression = "gzip"
-  uri = "https://api.uptrace.dev/api/v1/vector-logs"
-  headers.uptrace-dsn = "https://${UPTRACE_API_KEY}@api.uptrace.dev/${UPTRACE_PROJECT}"
-
+  uri = "https://api.uptrace.dev/api/v1/vector/logs"
+  headers.uptrace-dsn = "https://${UPTRACE_API_KEY}@uptrace.dev/${UPTRACE_PROJECT}"


### PR DESCRIPTION
```
encoding.codec = "ndjson"
```
->
```
encoding.codec = "json"
framing.method = "newline_delimited"
```

Source: https://github.com/vectordotdev/vector/blob/e224705d69ebbfbfe3063beea8cc899c0350744a/website/content/en/highlights/2022-08-16-0-24-0-upgrade-guide.md

Thanks for your change, @modellurgist!

