### PR TITLE
configurable region for new relic sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ One of these is required for New Relic logs. New Relic recommend the license key
 | ----------------------- | -------------------------------- |
 | `NEW_RELIC_INSERT_KEY`  | (optional) New Relic Insert key  |
 | `NEW_RELIC_LICENSE_KEY` | (optional) New Relic License key |
+| `NEW_RELIC_REGION`      | (optional) eu or us (default us) |
+| `NEW_RELIC_ACCOUNT_ID`  | New Relic Account Id             |
 
 ### Papertrail
 

--- a/vector-configs/sinks/new_relic.toml
+++ b/vector-configs/sinks/new_relic.toml
@@ -1,6 +1,8 @@
 [sinks.new_relic]
   # General
-  type = "new_relic_logs"
+  type = "new_relic"
   inputs = ["log_json"]
-  compression = "gzip" 
-
+  compression = "gzip"
+  region = "${NEW_RELIC_REGION}"
+  account_id = "${NEW_RELIC_ACCOUNT_ID}"
+  api = "logs"


### PR DESCRIPTION
env var `NEW_RELIC_REGION` has been added to configure the region (us or eu as of now)

[BREAKING] also updated the new relic file to the latest version. the current one in fly-log-shipper is deprecated. the new version also requires an additional env var - `NEW_RELIC_ACCOUNT_ID`