### PR TITLE
Add support for ddsource for datadog

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,11 @@ Set the secrets below associated with your desired log destination
 
 ### Datadog
 
-| Secret            | Description                                   |
-| ----------------- | --------------------------------------------- |
-| `DATADOG_API_KEY` | API key for your Datadog account              |
-| `DATADOG_SITE`    | (optional) The Datadog site. ie: datadoghq.eu |
+| Secret            | Description                                           |
+| ----------------- | ----------------------------------------------------- |
+| `DATADOG_API_KEY` | API key for your Datadog account                      |
+| `DATADOG_SITE`    | (optional) The Datadog site. ie: datadoghq.eu         |
+| `DATADOG_SOURCE`  | (optional) Sets the `ddsource` field on each log line |
 
 ### Honeycomb
 

--- a/vector-configs/sinks/datadog.toml
+++ b/vector-configs/sinks/datadog.toml
@@ -1,11 +1,20 @@
+[transforms.datadog_remap]
+  type = "remap"
+  inputs = ["log_json"]
+  source = '''
+  ddsource, err = get_env_var("DATADOG_SOURCE")
+  if err != null {
+    .ddsource = ddsource
+  }
+  '''
+
 [sinks.datadog]
   # General
   type = "datadog_logs" # required
-  inputs = ["log_json"] # required
+  inputs = ["datadog_remap"] # required
   api_key = "${DATADOG_API_KEY}" # required
   site = "${DATADOG_SITE:-datadoghq.com}" # optional
   compression = "gzip" # optional, default
 
   # Healthcheck
   healthcheck.enabled = true # optional, default
-


### PR DESCRIPTION
I _think_ this is correct. It should allow users to set `DATADOG_SOURCE=<something>` and have a new field in their logs like: `"ddsource": "<something>"`.

This is untested...