### PR TITLE
feat: remap logflare log level

### DIFF
--- a/vector-configs/sinks/logflare.toml
+++ b/vector-configs/sinks/logflare.toml
@@ -1,5 +1,5 @@
 [transforms.remap_logflare_loglevel]
-  type = "remap
+  type = "remap"
   inputs = ["log_json"]
   source = '''
     .level = .log.level

--- a/vector-configs/sinks/logflare.toml
+++ b/vector-configs/sinks/logflare.toml
@@ -1,6 +1,13 @@
+[transforms.remap_logflare_loglevel]
+  type = "remap
+  inputs = ["log_json"]
+  source = '''
+    .level = .log.level
+  '''
+
 [sinks.logflare]
   type = "http"
-  inputs = ["log_json"]
+  inputs = ["remap_logflare_loglevel"]
   uri = "https://api.logflare.app/logs/vector?api_key=${LOGFLARE_API_KEY}&source=${LOGFLARE_SOURCE_TOKEN}"
   encoding.codec = "json"
   compression = "none"


### PR DESCRIPTION
* Copies over `.log.level` to `.level` when using Logflare as a sink, enabling colour-coded candlebar graphs in Logflare's search UI, based on the error level:
  * <img width="591" alt="image" src="https://github.com/superfly/fly-log-shipper/assets/30039543/32515f68-b72a-41b0-a808-f34444fd2d2f">
  * Keeps `.log.level` around for backwards compatibility
