### PR TITLE
remap to expected logtail timestamp

### DIFF
--- a/vector-configs/sinks/logtail.toml
+++ b/vector-configs/sinks/logtail.toml
@@ -1,3 +1,10 @@
+[transforms.remap_logtail_timestamp]
+  type = "remap"
+  inputs = ["log_json"]
+  source = '''
+    .dt = del(.timestamp)
+  '''
+
 [sinks.logtail]
   type = "http"
   inputs = ["log_json"]

--- a/vector-configs/sinks/logtail.toml
+++ b/vector-configs/sinks/logtail.toml
@@ -8,7 +8,7 @@
 [sinks.logtail]
   type = "http"
   inputs = ["remap_logtail_timestamp"]
-  uri = "https://in.logtail.com"
+  uri = "https://in.logs.betterstack.com"
   encoding.codec = "json"
   auth.strategy = "bearer"
   auth.token = "${LOGTAIL_TOKEN}"

--- a/vector-configs/sinks/logtail.toml
+++ b/vector-configs/sinks/logtail.toml
@@ -7,7 +7,7 @@
 
 [sinks.logtail]
   type = "http"
-  inputs = ["log_json"]
+  inputs = ["remap_logtail_timestamp"]
   uri = "https://in.logtail.com"
   encoding.codec = "json"
   auth.strategy = "bearer"


### PR DESCRIPTION
As per discussion with Logtail support, the expected timestamp field is `dt` this remaps and removes `timestamp` from the source. 

RE: https://community.fly.io/t/fly-log-shipper-to-logtail-timestamp-differences/13878