### PR TITLE
Add highlight.io as an available sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Set the secrets below associated with your desired log destination
 | `DATADOG_API_KEY` | API key for your Datadog account              |
 | `DATADOG_SITE`    | (optional) The Datadog site. ie: datadoghq.eu |
 
+### Highlight
+
+| Secret                 | Description          |
+| ---------------------- | -------------------- |
+| `HIGHLIGHT_PROJECT_ID` | Highlight Project ID |
+
 ### Honeycomb
 
 | Secret              | Description       |

--- a/vector-configs/sinks/highlight.toml
+++ b/vector-configs/sinks/highlight.toml
@@ -1,0 +1,8 @@
+[sinks.highlight]
+  type = "http"
+  inputs = ["log_json"]
+  encoding.codec = "json"
+  framing.method = "newline_delimited"
+  compression = "gzip"
+  uri = "https://pub.highlight.io/v1/logs/json"
+  headers.x-highlight-project = "${HIGHLIGHT_PROJECT_ID}"


### PR DESCRIPTION
Provides a configuration for the fly logs shipper for https://app.highlight.io/
Additional docs for getting this set up: https://www.highlight.io/docs/getting-started/backend-logging/hosting/fly-io