### PR TITLE
Rename Logtail sink to Better Stack Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ Set the secrets below associated with your desired log destination
 | `AXIOM_TOKEN`   | Axiom token   |
 | `AXIOM_DATASET` | Axiom dataset |
 
+### Better Stack Logs (formerly Logtail)
+
+| Secret                      | Description                    |
+|-----------------------------|--------------------------------|
+| `BETTER_STACK_SOURCE_TOKEN` | Better Stack Logs source token |
+
 ### Datadog
 
 | Secret            | Description                                   |
@@ -111,12 +117,6 @@ Set the secrets below associated with your desired log destination
 | ----------------------- | ------------------------------------------------------- |
 | `LOGFLARE_API_KEY`      | Logflare ingest API key                                 |
 | `LOGFLARE_SOURCE_TOKEN` | Logflare source token (uuid on your Logflare dashboard) |
-
-### Better Stack Logs (formerly Logtail)
-
-| Secret                      | Description                    |
-|-----------------------------|--------------------------------|
-| `BETTER_STACK_SOURCE_TOKEN` | Better Stack Logs source token |
 
 ### Loki
 

--- a/README.md
+++ b/README.md
@@ -112,11 +112,11 @@ Set the secrets below associated with your desired log destination
 | `LOGFLARE_API_KEY`      | Logflare ingest API key                                 |
 | `LOGFLARE_SOURCE_TOKEN` | Logflare source token (uuid on your Logflare dashboard) |
 
-### Logtail
+### Better Stack Logs (formerly Logtail)
 
-| Secret          | Description        |
-| --------------- | ------------------ |
-| `LOGTAIL_TOKEN` | Logtail auth token |
+| Secret                      | Description                    |
+|-----------------------------|--------------------------------|
+| `BETTER_STACK_SOURCE_TOKEN` | Better Stack Logs source token |
 
 ### Loki
 

--- a/vector-configs/sinks/better-stack.toml
+++ b/vector-configs/sinks/better-stack.toml
@@ -1,15 +1,14 @@
-[transforms.remap_logtail_timestamp]
+[transforms.remap_better_stack_timestamp]
   type = "remap"
   inputs = ["log_json"]
   source = '''
     .dt = del(.timestamp)
   '''
 
-[sinks.logtail]
+[sinks.better_stack]
   type = "http"
-  inputs = ["remap_logtail_timestamp"]
+  inputs = ["remap_better_stack_timestamp"]
   uri = "https://in.logs.betterstack.com"
   encoding.codec = "json"
   auth.strategy = "bearer"
-  auth.token = "${LOGTAIL_TOKEN}"
-
+  auth.token = "${BETTER_STACK_SOURCE_TOKEN:-$LOGTAIL_TOKEN}"


### PR DESCRIPTION
Logtail has been rebranded as Better Stack Logs (details: https://betterstack.com/press/introducing-better-stack/)

In this PR I renamed only docs and ENV variable. The previous ENV variable `LOGTAIL_TOKEN` still works as a fallback for BC.

Manually tested with all ENV combinations, works like a charm 🙂 