### PR TITLE
Allow running log-shipper through a WireGuard connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ However for advanced uses you can still configure a NATs client in your apps to 
 | `ACCESS_TOKEN` | Fly personal access token (required; set with `fly secrets set ACCESS_TOKEN=$(fly auth token)`)                  |
 | `SUBJECT`      | Subject to subscribe to. See [[NATS]] below (defaults to `logs.>`)                                               |
 | `QUEUE`        | Arbitrary queue name if you want to run multiple log processes for HA and avoid duplicate messages being shipped |
+| `NETWORK`      | 6PN network, if you want to run log-shipper through a  WireGuard connection (defaults to `fdaa:0:0`)             |
 
 After generating your `fly.toml`, remember to update the internal port to match the `vector` internal port
 defined in `vector-configs/vector.toml`. Not doing so will result in health checks failing on deployment.

--- a/vector-configs/vector.toml
+++ b/vector-configs/vector.toml
@@ -7,7 +7,7 @@
 
 [sources.nats]
   type = "nats"
-  url = "nats://[fdaa::3]:4223"
+  url = "nats://[${NETWORK:fdaa}::3]:4223"
   queue = "${QUEUE-}"
   subject = "${SUBJECT-logs.>}"
   auth.strategy = "user_password"


### PR DESCRIPTION
I opted for on-premises deployment of the log-shipper rather than in fly.io cloud, so I had to use the 6PN network instead of `fdaa::`

I currently have the following dockerfile, with an env variable `SOURCE=fdaa:6:7985`:
```
FROM flyio/log-shipper:v0.0.5

RUN sed -i -e 's/fdaa::3/${SOURCE}::3/' /etc/vector/vector.toml
```

(The container is configured to use the WG peer as its default gateway, and I utilize route manipulations for the /120 subnet)