### PR TITLE
Add OpsVerse sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,14 @@ One of these is required for New Relic logs. New Relic recommend the license key
 | `NEW_RELIC_REGION`      | (optional) eu or us (default us) |
 | `NEW_RELIC_ACCOUNT_ID`  | New Relic Account Id             |
 
+### OpsVerse
+
+| Secret                  | Description            |
+| ----------------------- | ---------------------- |
+| `OPSVERSE_LOGS_ENDPOINT`| OpsVerse Logs Endpoint |
+| `OPSVERSE_USERNAME`     | OpsVerse Username      |
+| `OPSVERSE_PASSWORD`     | OpsVerse Password      |
+
 ### Papertrail
 
 | Secret                | Description         |

--- a/vector-configs/sinks/opsverse.toml
+++ b/vector-configs/sinks/opsverse.toml
@@ -1,0 +1,31 @@
+[transforms.loki_json]
+  type = "remap"
+  inputs = ["log_json"]
+  source = '''
+  .level = .log.level
+  if starts_with(.message, "{") ?? false {
+    # parse json messages
+    json = object!(parse_json!(.message))
+    del(.message)
+    . |= json
+  }
+  '''
+
+[sinks.opsverse]
+  type = "loki"
+  inputs = ["loki_json"]
+  endpoint = "${OPSVERSE_LOGS_ENDPOINT}"
+  compression = "gzip"
+  auth.strategy = "basic"
+  auth.user = "${OPSVERSE_USERNAME}"
+  auth.password = "${OPSVERSE_PASSWORD}"
+  encoding.codec = "logfmt"
+  out_of_order_action = "accept"
+
+  labels.event_provider = "{{event.provider}}"
+  labels.fly_region = "{{fly.region}}"
+  labels.fly_app_name = "{{fly.app.name}}"
+  labels.fly_app_instance = "{{fly.app.instance}}"
+  labels.host = "{{host}}"
+  labels.level = "{{level}}"
+


### PR DESCRIPTION
Adding sink for OpsVerse to allow `fly-log-shipper` to ship logs to [OpsVerse ObserveNow](https://opsverse.io/observenow-observability/) stacks