### PR TITLE
Correct typo when configuring `NETWORK` default

### DIFF
--- a/vector-configs/vector.toml
+++ b/vector-configs/vector.toml
@@ -7,7 +7,7 @@
 
 [sources.nats]
   type = "nats"
-  url = "nats://[${NETWORK:fdaa}::3]:4223"
+  url = "nats://[${NETWORK-fdaa}::3]:4223"
   queue = "${QUEUE-}"
   subject = "${SUBJECT-logs.>}"
   auth.strategy = "user_password"


### PR DESCRIPTION
This PR fixes a small typo, allowing the default value for `NETWORK` to be used correctly