### PR TITLE
Sinks | Add AWS CloudWatch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ Set the secrets below associated with your desired log destination
 | `AWS_REGION`            | Region for the bucket                                                                   |
 | `S3_ENDPOINT`           | (optional) Endpoint URL for S3 compatible object stores such as Cloudflare R2 or Wasabi |
 
+### AWS CloudWatch
+
+| Secret                  | Description                                                                             |
+| ----------------------- | --------------------------------------------------------------------------------------- |
+| `AWS_ACCESS_KEY_ID`     | AWS Access key with access to the log bucket                                            |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret access key                                                                   |
+| `AWS_REGION`            | Region for CloudWatch                                                                   |
+| `CLOUDWATCH_LOG_GROUP_NAME`           | Log Group to send logs to in CloudWatch |
+
 ### Axiom
 
 | Secret          | Description   |

--- a/vector-configs/sinks/aws_cloudwatch.toml
+++ b/vector-configs/sinks/aws_cloudwatch.toml
@@ -1,0 +1,12 @@
+[sinks.aws_cloudwatch]
+  type = "aws_cloudwatch_logs"
+  inputs = [ "log_json" ]
+  create_missing_group = true
+  create_missing_stream = true
+  group_name = "${CLOUDWATCH_LOG_GROUP_NAME}"
+  compression = "none"
+  region = "${AWS_REGION}"
+  stream_name = "{{ fly.app.name }}/{{ host }}"
+
+[sinks.aws_cloudwatch.encoding]
+  codec = "json"


### PR DESCRIPTION
## Context

- Add support to `AWS CloudWatch` as one of the sinks for the shipper;

## Acknowledgement

- These changes were made initially by @jdjkelly in [this PR](https://github.com/superfly/fly-log-shipper/pull/18), which ended up getting stale. Only revived it and solved the conflicts