### PR TITLE
doc: Update ACCESS_TOKEN description in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ However for advanced uses you can still configure a NATs client in your apps to 
 | Secret         | Description                                                                                                      |
 | -------------- | ---------------------------------------------------------------------------------------------------------------- |
 | `ORG`          | Organisation slug (default to `personal`)                                                                        |
-| `ACCESS_TOKEN` | Fly personal access token (required; set with `fly secrets set ACCESS_TOKEN=$(fly auth token)`)                  |
+| `ACCESS_TOKEN` | Fly personal access token (required; set with `fly secrets set ACCESS_TOKEN=$(fly tokens create)`)                  |
 | `SUBJECT`      | Subject to subscribe to. See [[NATS]] below (defaults to `logs.>`)                                               |
 | `QUEUE`        | Arbitrary queue name if you want to run multiple log processes for HA and avoid duplicate messages being shipped |
 | `NETWORK`      | 6PN network, if you want to run log-shipper through a  WireGuard connection (defaults to `fdaa:0:0`)             |


### PR DESCRIPTION
Prevent the flyctl error message:

```
The 'fly auth token' command is deprecated. Use 'fly tokens create' instead.
```