### PR TITLE
Allow custom Better Stack URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Set the secrets below associated with your desired log destination
 | Secret                      | Description                    |
 |-----------------------------|--------------------------------|
 | `BETTER_STACK_SOURCE_TOKEN` | Better Stack Logs source token |
+| `BETTER_STACK_URI`          | Better Stack Logs source URI (default is "https://in.logs.betterstack.com") |
 
 ### Datadog
 

--- a/vector-configs/sinks/better-stack.toml
+++ b/vector-configs/sinks/better-stack.toml
@@ -8,7 +8,7 @@
 [sinks.better_stack]
   type = "http"
   inputs = ["remap_better_stack_timestamp"]
-  uri = "https://in.logs.betterstack.com"
+  uri = "${BETTER_STACK_URI:-https://in.logs.betterstack.com}"
   encoding.codec = "json"
   auth.strategy = "bearer"
   auth.token = "${BETTER_STACK_SOURCE_TOKEN:-$LOGTAIL_TOKEN}"


### PR DESCRIPTION
Some Better Stack Telemetry sources can have a custom ingestion host URI (e.g. `*.*.betterstack.com`)