### PR TITLE
Sinks | Add OpenObserve sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,14 @@ One of these is required for New Relic logs. New Relic recommend the license key
 | `NEW_RELIC_REGION`      | (optional) eu or us (default us) |
 | `NEW_RELIC_ACCOUNT_ID`  | New Relic Account Id             |
 
+### OpenObserve
+
+| Secret                 | Description          |
+| ---------------------- | -------------------- |
+| `OPENOBSERVE_URI`      | OpenObserve URI      |
+| `OPENOBSERVE_USER`     | OpenObserve user     |
+| `OPENOBSERVE_PASSWORD` | OpenObserve password |
+
 ### OpsVerse
 
 | Secret                  | Description            |

--- a/vector-configs/sinks/openobserve.toml
+++ b/vector-configs/sinks/openobserve.toml
@@ -1,0 +1,12 @@
+[sinks.openobserve]
+type = "http"
+inputs = [ "log_json" ]
+uri = "${OPENOBSERVE_URI}"
+method = "post"
+auth.strategy = "basic"
+auth.user = "${OPENOBSERVE_USER}"
+auth.password = "${OPENOBSERVE_PASSWORD}"
+compression = "gzip"
+encoding.codec = "json"
+encoding.timestamp_format = "rfc3339"
+healthcheck.enabled = false


### PR DESCRIPTION
Adds [OpenObserve](https://openobserve.ai/) sink.

## Testing
We have deployed it ourselves in production and it works as expected!
![image](https://github.com/user-attachments/assets/088cd328-bc16-41e4-841b-7e4e5eeb28fc)
