### PR TITLE
feat: update the signoz sink and provider configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ One of these is required for New Relic logs. New Relic recommend the license key
 
 See [SigNoz Docs](https://signoz.io/docs/ingestion/signoz-cloud/overview/) for region-specific Ingestion URLs and Keys.
 
+For **self-hosted SigNoz**, set `SIGNOZ_INGESTION_URL` to your own ingestion endpoint — see [Self-Hosted Ingestion](https://signoz.io/docs/ingestion/self-hosted/overview/). `SIGNOZ_INGESTION_KEY` is only required for SigNoz Cloud and can be left unset for self-hosted deployments.
+
 ### Uptrace
 
 | Secret                  | Description        |

--- a/README.md
+++ b/README.md
@@ -192,13 +192,14 @@ One of these is required for New Relic logs. New Relic recommend the license key
 | `SEMATEXT_REGION` | Sematext region |
 | `SEMATEXT_TOKEN`  | Sematext token  |
 
+### SigNoz
 
-### Signoz
+| Secret                 | Description                                                                    |
+| ---------------------- | ------------------------------------------------------------------------------ |
+| `SIGNOZ_INGESTION_KEY` | SigNoz Ingestion Key                                                           |
+| `SIGNOZ_INGESTION_URL` | SigNoz Ingestion URL (default is `https://ingest.us.signoz.cloud/logs/vector`) |
 
-| Secret                | Description                                                     |
-| --------------------- | --------------------------------------------------------------- |
-| `SIGNOZ_INGESTION_KEY`| Signoz Access Token                                             |
-| `SIGNOZ_URI`       | Signoz URI (default is 'https://ingest.us.signoz.cloud/logs/vector') |
+See [SigNoz Docs](https://signoz.io/docs/ingestion/signoz-cloud/overview/) for region-specific Ingestion URLs and Keys.
 
 ### Uptrace
 

--- a/vector-configs/sinks/signoz.toml
+++ b/vector-configs/sinks/signoz.toml
@@ -1,13 +1,15 @@
 [sinks.signoz]
+# See https://signoz.io/docs/logs-management/send-logs/vector-logs-to-signoz/
+# for more details
 type = "http"
 inputs = ["log_json"]
-# Potential regions: "us", "eu", "in"
-# See https://signoz.io/docs/logs-management/send-logs/vector-logs-to-signoz/ 
+# Potential regions: "us", "eu", "in", "us2", "eu2", "in2"
+# See https://signoz.io/docs/ingestion/signoz-cloud/overview/
 # for more details
-uri = "${SIGNOZ_URI:-https://ingest.us.signoz.cloud/logs/vector}"
+uri = "${SIGNOZ_INGESTION_URL:-https://ingest.us.signoz.cloud/logs/vector}"
 
 [sinks.signoz.encoding]
 codec = "json"
 
 [sinks.signoz.request.headers]
-signoz-access-token = "${SIGNOZ_INGESTION_KEY}"
+signoz-ingestion-key = "${SIGNOZ_INGESTION_KEY}"


### PR DESCRIPTION
### Summary

Clean up and correctness fixes for the SigNoz sink.                                                                                                                                                                                               
  - Renamed header signoz-access-token → signoz-ingestion-key to match SigNoz Cloud's current ingestion API.
  - Renamed env var SIGNOZ_URI → SIGNOZ_INGESTION_URL for consistency with SIGNOZ_INGESTION_KEY.                                                    
  - Updated region list to include the newer regions: us2, eu2, in2                  
  - Updated the doc link to the canonical ingestion overview page                                             