### PR TITLE
feat: upgrade Vector to 0.55.0 and add optional Axiom regional edge support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM timberio/vector:0.29.1-debian
+FROM timberio/vector:0.55.0-debian
 COPY vector-configs /etc/vector/
 COPY ./start-fly-log-transporter.sh .
 CMD ["bash", "start-fly-log-transporter.sh"]

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Set the secrets below associated with your desired log destination
 | --------------- | ------------- |
 | `AXIOM_TOKEN`   | Axiom token   |
 | `AXIOM_DATASET` | Axiom dataset |
+| `AXIOM_REGION`  | (optional) Axiom regional edge domain for data locality (e.g. `eu-central-1.aws.edge.axiom.co`). Omit for the default US East 1 endpoint. See [Axiom edge deployments](https://axiom.co/docs/reference/edge-deployments) for available values. |
 
 ### Baselime
 

--- a/vector-configs/sinks/axiom.toml
+++ b/vector-configs/sinks/axiom.toml
@@ -3,4 +3,5 @@
   inputs = ["log_json"]
   token = "${AXIOM_TOKEN}"
   dataset = "${AXIOM_DATASET}"
+  ${AXIOM_REGION:+region = "${AXIOM_REGION}"}
 


### PR DESCRIPTION
What and why

The current Vector image (`0.29.1`) predates Axiom's regional edge support, so the Axiom sink always routes data to the US endpoint — even when a user's organization is on the EU deployment. This makes `fly-log-shipper` unusable with Axiom's `eu-central-1` edge dataset.

Vector `0.52.0` added a `region` field to the Axiom sink that routes ingest traffic to the correct edge domain. This PR bumps Vector to `0.55.0` and exposes that field as an optional `AXIOM_REGION` secret.

## Changes

- **`Dockerfile`** — bumps `timberio/vector:0.29.1-debian` → `0.55.0-debian`
- **`vector-configs/axiom.toml`** — adds an optional `region` line using the existing shell templating pattern; the line is omitted entirely when `AXIOM_REGION` is unset, so existing users see no change in behaviour
- **`README.md`** — documents `AXIOM_REGION` in the Axiom secrets table

## Usage

For EU users, set:

```bash
fly secrets set AXIOM_REGION=eu-central-1.aws.edge.axiom.co
```

Leave it unset to keep the existing US endpoint behaviour. See [[Axiom edge deployments](https://axiom.co/docs/reference/edge-deployments)](https://axiom.co/docs/reference/edge-deployments) for all available values.

## Backwards compatibility

No breaking changes. The `AXIOM_REGION` variable is fully optional, and the Vector `0.55.0` image is compatible with all existing sink configurations in this repo.